### PR TITLE
Fix typo in download additional plugins link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@ Hackolade plugin for Apache Parquet schema
 
 Hackolade exposes its core data modeling engine through a plugin architecture.  Each plugin applies the Hackolade data modeling capabilities to a specific target technology, whether for data-at-rest (databases) or data-in-motion (communications.)  Each plugin matches the specific aspects of the target in terms of terminology, storage model, data types, and communication protocol.
 
-To enable data modeling capabilities for a target, you must first download and install the plugin, following these [instructions](https://hackolade.com/help/DownloadadditionalDBtargetplugin.htm "Plugin download instructions").
+To enable data modeling capabilities for a target, you must first download and install the plugin, following these [instructions](https://hackolade.com/help/DownloadadditionalDBtargetplugin.html "Plugin download instructions").
 
 Plugins can be customized by following these [instructions](https://hackolade.com/help/Userdefinedcustomproperties.html "Plugin customization instructions").


### PR DESCRIPTION
# Content

- [x] Fix the documentation link typo

cc @pdesmarets